### PR TITLE
Update .obo file

### DIFF
--- a/xenopus_anatomy.obo
+++ b/xenopus_anatomy.obo
@@ -21,6 +21,8 @@ ontology: xao
 property_value: http://purl.org/dc/elements/1.1/description "XAO represents the anatomy and development of the African frogs Xenopus laevis and tropicalis." xsd:string
 property_value: http://purl.org/dc/elements/1.1/title "Xenopus Anatomy Ontology" xsd:string
 property_value: http://purl.org/dc/terms/license https://creativecommons.org/licenses/by/3.0/ xsd:string
+property_value: IAO:0000700 XAO:0000000
+property_value: IAO:0000700 XAO:1000000
 
 [Term]
 id: XAO:0000000


### PR DESCRIPTION
Related to https://github.com/OBOFoundry/OBOFoundry.github.io/issues/2149

# What this Does
Applies the annotation property [has ontology root term (IAO:0000700)](http://purl.obolibrary.org/obo/IAO_0000700) to
* XAO:0000000
* XAO:1000000

# Why this is helpful
the Ontology Lookup Service uses this to help better display ontologies
if the terms mentioned above are ever aligned with an upper ontology like BFO, it still will be the thing shown on OLS as the "root"
this will be generally useful for things like alignment with COB since it makes it easier to figure out where the work will be

cc @matentzn and @cthoyt